### PR TITLE
Adding Readme including steps to run the book locally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# ⚓ The Anchor Book
+
+Get up and running with [Anchor](https://anchor-lang.com), the framework for building secure, reliable
+Solana apps.
+
+## 🤝 Contributing
+
+Feel free to file an issue or submit a pull request.
+
+## 💻 Run The Anchor Book Locally
+
+To run on a Mac, install [Homebrew](https://brew.sh/) if you don't already have
+it.
+
+Then, run the following commands:
+
+```sh
+brew upgrade
+brew install mdbook
+```
+
+Next, clone this repo and run `mbdbook` to build the book:
+
+```sh
+git clone https://github.com/project-serum/anchor-book.git
+cd anchor-book
+mdbook build
+```
+
+Now, assuming you have [node.js](https://nodejs.org) and
+[npm](https://npmjs.com) installed, install `serve`, a static file server.
+
+```sh
+npm i -g serve
+```
+
+Now, run:
+
+```sh
+cd book && serve
+```
+
+and then navigate to `http://localhost:3000`
+in your browser.
+
+## LICENSE
+
+UNLICENSED


### PR DESCRIPTION
Just adding a README and the ability for folks to run the book locally in the case GitHub pages are offline (which it is at the time of this writing).

Some items to consider:

1. Right now the repo is 'UNLICENSED' which disables some folks working at corporations to contribute. Consider adding MIT or Apache 2.0 to keep it OSS.
2. I added only a basic section for contributing. If there is a contributor's license agreement or GitHub issue template to use, we should add it.
