### PR TITLE
Change `Result<()>` to `ProgramResult`

### DIFF
--- a/src/chapter_3/CPIs.md
+++ b/src/chapter_3/CPIs.md
@@ -21,11 +21,11 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 #[program]
 pub mod puppet {
     use super::*;
-    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {
+    pub fn initialize(_ctx: Context<Initialize>) -> ProgramResult {
         Ok(())
     }
 
-    pub fn set_data(ctx: Context<SetData>, data: u64) -> Result<()> {
+    pub fn set_data(ctx: Context<SetData>, data: u64) -> ProgramResult {
         let puppet = &mut ctx.accounts.puppet;
         puppet.data = data;
         Ok(())
@@ -72,7 +72,7 @@ declare_id!("HmbTLCmaGvZhKnn1Zfa1JVnp7vkMV4DYVxPLWBVoN65L");
 #[program]
 mod puppet_master {
     use super::*;
-    pub fn pull_strings(ctx: Context<PullStrings>, data: u64) -> Result<()> {
+    pub fn pull_strings(ctx: Context<PullStrings>, data: u64) -> ProgramResult {
         let cpi_program = ctx.accounts.puppet_program.to_account_info();
         let cpi_accounts = SetData {
             puppet: ctx.accounts.puppet.to_account_info(),
@@ -111,7 +111,7 @@ declare_id!("HmbTLCmaGvZhKnn1Zfa1JVnp7vkMV4DYVxPLWBVoN65L");
 #[program]
 mod puppet_master {
     use super::*;
-    pub fn pull_strings(ctx: Context<PullStrings>, data: u64) -> Result<()> {
+    pub fn pull_strings(ctx: Context<PullStrings>, data: u64) -> ProgramResult {
         puppet::cpi::set_data(ctx.accounts.set_data_ctx(), data)
     }
 }
@@ -191,7 +191,7 @@ pub struct Data {
 
 and adjust the `initialize` function:
 ```rust,ignore
-pub fn initialize(ctx: Context<Initialize>, authority: Pubkey) -> Result<()> {
+pub fn initialize(ctx: Context<Initialize>, authority: Pubkey) -> ProgramResult {
     ctx.accounts.puppet.authority = authority;
     Ok(())
 }
@@ -233,7 +233,7 @@ declare_id!("HmbTLCmaGvZhKnn1Zfa1JVnp7vkMV4DYVxPLWBVoN65L");
 #[program]
 mod puppet_master {
     use super::*;
-    pub fn pull_strings(ctx: Context<PullStrings>, data: u64) -> Result<()> {
+    pub fn pull_strings(ctx: Context<PullStrings>, data: u64) -> ProgramResult {
         puppet::cpi::set_data(ctx.accounts.set_data_ctx(), data)
     }
 }

--- a/src/chapter_3/PDAs.md
+++ b/src/chapter_3/PDAs.md
@@ -109,7 +109,7 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 pub mod game {
     use super::*;
     // handler function
-    pub fn create_user_stats(ctx: Context<CreateUserStats>, name: String) -> Result<()> {
+    pub fn create_user_stats(ctx: Context<CreateUserStats>, name: String) -> ProgramResult {
         let user_stats = &mut ctx.accounts.user_stats;
         user_stats.level = 0;
         if name.as_bytes().len() > 200 {
@@ -163,7 +163,7 @@ pub struct ChangeUserName<'info> {
 and another handler function:
 ```rust,ignore
 // handler function (add this next to the create_user_stats function in the game module)
-pub fn change_user_name(ctx: Context<ChangeUserName>, new_name: String) -> Result<()> {
+pub fn change_user_name(ctx: Context<ChangeUserName>, new_name: String) -> ProgramResult {
     if new_name.as_bytes().len() > 200 {
         // proper error handling omitted for brevity
         panic!();
@@ -252,7 +252,7 @@ declare_id!("HmbTLCmaGvZhKnn1Zfa1JVnp7vkMV4DYVxPLWBVoN65L");
 #[program]
 mod puppet_master {
     use super::*;
-    pub fn pull_strings(ctx: Context<PullStrings>, bump: u8, data: u64) -> Result<()> {
+    pub fn pull_strings(ctx: Context<PullStrings>, bump: u8, data: u64) -> ProgramResult {
         let bump = &[bump][..];
         puppet::cpi::set_data(
             ctx.accounts.set_data_ctx().with_signer(&[&[bump][..]]),

--- a/src/chapter_3/errors.md
+++ b/src/chapter_3/errors.md
@@ -23,7 +23,7 @@ To actually throw an error use the [`err!`](https://docs.rs/anchor-lang/latest/a
 #[program]
 mod hello_anchor {
     use super::*;
-    pub fn set_data(ctx: Context<SetData>, data: MyAccount) -> Result<()> {
+    pub fn set_data(ctx: Context<SetData>, data: MyAccount) -> ProgramResult {
         if data.data >= 100 {
             return err!(MyError::DataTooLarge);    
         }
@@ -47,7 +47,7 @@ You can use the [`require`](https://docs.rs/anchor-lang/latest/anchor_lang/macro
 #[program]
 mod hello_anchor {
     use super::*;
-    pub fn set_data(ctx: Context<SetData>, data: MyAccount) -> Result<()> {
+    pub fn set_data(ctx: Context<SetData>, data: MyAccount) -> ProgramResult {
         require!(data.data < 100, MyError::DataTooLarge); 
         ctx.accounts.my_account.set_inner(data);
         Ok(())

--- a/src/chapter_3/high-level_overview.md
+++ b/src/chapter_3/high-level_overview.md
@@ -13,7 +13,7 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 #[program]
 mod hello_anchor {
     use super::*;
-    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {
+    pub fn initialize(_ctx: Context<Initialize>) -> ProgramResult {
         Ok(())
     }
 }

--- a/src/chapter_3/milestone_project_tic-tac-toe.md
+++ b/src/chapter_3/milestone_project_tic-tac-toe.md
@@ -109,7 +109,7 @@ And with this, `SetupGame` is complete and we can move on to the `setup_game` fu
 
 Let's start by adding an argument to the `setup_game` function.
 ```rust,ignore
-pub fn setup_game(ctx: Context<SetupGame>, player_two: Pubkey) -> Result<()> {
+pub fn setup_game(ctx: Context<SetupGame>, player_two: Pubkey) -> ProgramResult {
     Ok(())
 }
 ```
@@ -117,7 +117,7 @@ Why didn't we just add `player_two` as an account in the accounts struct? There 
 
 Finish the instruction function by setting the game to its initial values:
 ```rust,ignore
-pub fn setup_game(ctx: Context<SetupGame>, player_two: Pubkey) -> Result<()> {
+pub fn setup_game(ctx: Context<SetupGame>, player_two: Pubkey) -> ProgramResult {
     let game = &mut ctx.accounts.game;
     game.players = [ctx.accounts.player_one.key(), player_two];
     game.turn = 1;
@@ -206,7 +206,7 @@ impl Game {
         self.players[self.current_player_index()]
     }
 
-    pub fn play(&mut self, tile: &Tile) -> Result<()> {
+    pub fn play(&mut self, tile: &Tile) -> ProgramResult {
         if !self.is_active() {
             return err!(TicTacToeError::GameAlreadyOver);
         }
@@ -317,7 +317,7 @@ pub enum TicTacToeError {
 
 Finally, we can add the `play` function inside the program module.
 ```rust,ignore
-pub fn play(ctx: Context<Play>, tile: Tile) -> Result<()> {
+pub fn play(ctx: Context<Play>, tile: Tile) -> ProgramResult {
     let game = &mut ctx.accounts.game;
 
     require!(

--- a/src/chapter_3/the_accounts_struct.md
+++ b/src/chapter_3/the_accounts_struct.md
@@ -22,7 +22,7 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 #[program]
 mod hello_anchor {
     use super::*;
-    pub fn set_data(ctx: Context<SetData>, data: u64) -> Result<()> {
+    pub fn set_data(ctx: Context<SetData>, data: u64) -> ProgramResult {
         ctx.accounts.my_account.data = data;
         Ok(())
     }
@@ -57,7 +57,7 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 #[program]
 mod hello_anchor {
     use super::*;
-    pub fn set_data(ctx: Context<SetData>, data: u64) -> Result<()> {
+    pub fn set_data(ctx: Context<SetData>, data: u64) -> ProgramResult {
         if ctx.accounts.token_account.amount > 0 {
             ctx.accounts.my_account.data = data;
         }

--- a/src/chapter_3/the_program_module.md
+++ b/src/chapter_3/the_program_module.md
@@ -5,7 +5,7 @@ The program module is where you define your business logic. You do so by writing
 #[program]
 mod hello_anchor {
     use super::*;
-    pub fn set_data(ctx: Context<SetData>, data: u64) -> Result<()> {
+    pub fn set_data(ctx: Context<SetData>, data: u64) -> ProgramResult {
         if ctx.accounts.token_account.amount > 0 {
             ctx.accounts.my_account.data = data;
         }
@@ -30,7 +30,7 @@ If your function requires instruction data, you can add it by adding arguments t
 #[program]
 mod hello_anchor {
     use super::*;
-    pub fn set_data(ctx: Context<SetData>, data: Data) -> Result<()> {
+    pub fn set_data(ctx: Context<SetData>, data: Data) -> ProgramResult {
         ctx.accounts.my_account.data = data.data;
         ctx.accounts.my_account.age = data.age;
         Ok(())
@@ -61,7 +61,7 @@ Conveniently, `#[account]` implements `Anchor(De)Serialize` for `MyAccount`, so 
 #[program]
 mod hello_anchor {
     use super::*;
-    pub fn set_data(ctx: Context<SetData>, data: MyAccount) -> Result<()> {
+    pub fn set_data(ctx: Context<SetData>, data: MyAccount) -> ProgramResult {
         ctx.accounts.my_account.set_inner(data);
         Ok(())
     }


### PR DESCRIPTION
An alias of `Result<T>` is generated from the `errors` macro. This means
that any examples that don't use the `errors` macro will fail at compile
time.

For a beginner to Rust, this can lead to a confusing error that's hard to
debug.

My suggestion is to standardize on `ProgramResult` which is also used in
the examples section of the Anchor repo and will always be available
from `use anchor_lang::prelude::*;`