### PR TITLE
Add instructions for generating a local keypair

### DIFF
--- a/src/chapter_3/milestone_project_tic-tac-toe.md
+++ b/src/chapter_3/milestone_project_tic-tac-toe.md
@@ -176,6 +176,9 @@ Now, run `anchor test`. This starts up (and subsequently shuts down) a local val
 > This is likely because the test file is looking for types from your program that haven't been generated yet.
 > To generate them, run `anchor build`. This builds the program and creates the idl and typescript types.
 
+
+If you get the error `Error: Unable to read keypair file` when running the test, you likely need to generate a Solana keypair using `solana-keygen new`.
+
 ## Playing the game
 
 ### The Play Instruction


### PR DESCRIPTION
While going through chapter 3,  I ran into a roadblock not covered by the Anchor Book when testing the tic-tac-toe program. 

Running the test resulted in the error `Error: unable to read keypair file`. 

New users likely will not have ran `solana-keygen new` before doing this example. 

Added instructions to run `solana-keygen new` if test fails for this reason.