### PR TITLE
fix(milestone): make sure code snippet compiles and some formatting

### DIFF
--- a/src/anchor_in_depth/milestone_project_tic-tac-toe.md
+++ b/src/anchor_in_depth/milestone_project_tic-tac-toe.md
@@ -278,7 +278,7 @@ Time to test our code! Head over into the `tests` folder in the root directory. 
 ```typescript
   it('setup game!', async() => {
     const gameKeypair = anchor.web3.Keypair.generate();
-    const playerOne = program.provider.wallet;
+    const playerOne = (program.provider as anchor.AnchorProvider).wallet;
     const playerTwo = anchor.web3.Keypair.generate();
     await program.methods
       .setupGame(playerTwo.publicKey)

--- a/src/anchor_references/cli.md
+++ b/src/anchor_references/cli.md
@@ -212,20 +212,16 @@ of all workspace programs before running them.
 If the configured network is a localnet, then automatically starts the localnetwork and runs
 the test.
 
-::: tip Note
-Be sure to shutdown any other local validators, otherwise `anchor test` will fail to run.
-
-If you'd prefer to run the program against your local validator use `anchor test --skip-local-validator`.
-:::
+> Note: Be sure to shutdown any other local validators, otherwise `anchor test` will fail to run.
+> 
+> If you'd prefer to run the program against your local validator use `anchor test --skip-local-validator`.
 
 When running tests we stream program logs to `.anchor/program-logs/<address>.<program-name>.log`
 
-::: tip Note
-The Anchor workflow [recommends](https://www.parity.io/paritys-checklist-for-secure-smart-contract-development/)
-to test your program using integration tests in a language other
-than Rust to make sure that bugs related to syntax misunderstandings
-are coverable with tests and not just replicated in tests.
-:::
+> Note: The Anchor workflow [recommends](https://www.parity.io/paritys-checklist-for-secure-smart-contract-development/)
+> to test your program using integration tests in a language other
+> than Rust to make sure that bugs related to syntax misunderstandings
+> are coverable with tests and not just replicated in tests.
 
 ## Upgrade
 


### PR DESCRIPTION
_Sorry for the trickle. I'm not actively looking at this but I keep running into things and my compulsions kick in..._

Re the test code change, I just wanted to make the smallest change possible to make the snippet valid ts code. I realise `programs/tic-tac-toe` has moved on significantly from these snippets. It is probably worth switching to [includes](https://github.com/project-serum/anchor-book/tree/master/programs/tic-tac-toe) and code anchors (pun!) like Rust book does, to avoid getting out-of-sync.

Re callout change, i think that was just copy-paste from the old site and doesn't render in mdbook.