### PR TITLE
Adding libssl-dev build dependency as command

### DIFF
--- a/src/getting_started/installation.md
+++ b/src/getting_started/installation.md
@@ -58,7 +58,9 @@ cargo install --git https://github.com/project-serum/anchor --tag v0.24.1 anchor
 On Linux systems you may need to install additional dependencies if cargo install fails. On Ubuntu,
 
 ```
-sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y pkg-config build-essential libudev-dev
+sudo apt-get update && \
+sudo apt-get upgrade && \
+sudo apt-get install -y pkg-config build-essential libudev-dev libssl-dev
 ```
 
 Now verify the CLI is installed properly.


### PR DESCRIPTION
Adds libssl-dev build dependency as command on the install guide.