### PR TITLE
playerOne should be `(program.provider as anchor.AnchorProvider).wallet;` otherwise it could get syntax error

### DIFF
--- a/src/anchor_in_depth/milestone_project_tic-tac-toe.md
+++ b/src/anchor_in_depth/milestone_project_tic-tac-toe.md
@@ -383,7 +383,7 @@ You can create then a new `it` test, setup the game like in the previous test, b
 ```typescript
 it('player one wins', async() => {
     const gameKeypair = anchor.web3.Keypair.generate();
-    const playerOne = program.provider.wallet;
+    const playerOne = (program.provider as anchor.AnchorProvider).wallet;
     const playerTwo = anchor.web3.Keypair.generate();
     await program.methods
       .setupGame(playerTwo.publicKey)


### PR DESCRIPTION
- playerOne should be `(program.provider as anchor.AnchorProvider).wallet;`