### PR TITLE
feat(tic-tac-toe): use anchor includes for code snippets

### DIFF
--- a/programs/tic-tac-toe/programs/tic-tac-toe/Cargo.toml
+++ b/programs/tic-tac-toe/programs/tic-tac-toe/Cargo.toml
@@ -17,5 +17,7 @@ default = []
 
 [dependencies]
 anchor-lang = "=0.24.1"
+# ANCHOR: deps
 num-traits = "0.2"
 num-derive = "0.3"
+# ANCHOR_END: deps

--- a/programs/tic-tac-toe/programs/tic-tac-toe/src/errors.rs
+++ b/programs/tic-tac-toe/programs/tic-tac-toe/src/errors.rs
@@ -1,5 +1,6 @@
 use anchor_lang::error_code;
 
+// ANCHOR: errors
 #[error_code]
 pub enum TicTacToeError {
     TileOutOfBounds,
@@ -8,3 +9,4 @@ pub enum TicTacToeError {
     NotPlayersTurn,
     GameAlreadyStarted,
 }
+// ANCHOR_END: errors

--- a/programs/tic-tac-toe/programs/tic-tac-toe/src/instructions/play.rs
+++ b/programs/tic-tac-toe/programs/tic-tac-toe/src/instructions/play.rs
@@ -2,6 +2,7 @@ use crate::errors::TicTacToeError;
 use crate::state::game::*;
 use anchor_lang::prelude::*;
 
+// ANCHOR: fn
 pub fn play(ctx: Context<Play>, tile: Tile) -> Result<()> {
     let game = &mut ctx.accounts.game;
 
@@ -13,10 +14,13 @@ pub fn play(ctx: Context<Play>, tile: Tile) -> Result<()> {
 
     game.play(&tile)
 }
+// ANCHOR_END: fn
 
+// ANCHOR: struct
 #[derive(Accounts)]
 pub struct Play<'info> {
     #[account(mut)]
     pub game: Account<'info, Game>,
     pub player: Signer<'info>,
 }
+// ANCHOR_END: struct

--- a/programs/tic-tac-toe/programs/tic-tac-toe/src/instructions/setup_game.rs
+++ b/programs/tic-tac-toe/programs/tic-tac-toe/src/instructions/setup_game.rs
@@ -1,12 +1,15 @@
 use crate::state::game::*;
 use anchor_lang::prelude::*;
 
+// ANCHOR: fn
 pub fn setup_game(ctx: Context<SetupGame>, player_two: Pubkey) -> Result<()> {
     ctx.accounts
         .game
         .start([ctx.accounts.player_one.key(), player_two])
 }
+// ANCHOR_END: fn
 
+// ANCHOR: struct
 #[derive(Accounts)]
 pub struct SetupGame<'info> {
     #[account(init, payer = player_one, space = Game::MAXIMUM_SIZE + 8)]
@@ -15,3 +18,4 @@ pub struct SetupGame<'info> {
     pub player_one: Signer<'info>,
     pub system_program: Program<'info, System>,
 }
+// ANCHOR_END: struct

--- a/programs/tic-tac-toe/programs/tic-tac-toe/src/state/game.rs
+++ b/programs/tic-tac-toe/programs/tic-tac-toe/src/state/game.rs
@@ -1,8 +1,11 @@
 use crate::errors::TicTacToeError;
 use anchor_lang::prelude::*;
+// ANCHOR: use
 use num_derive::*;
 use num_traits::*;
+// ANCHOR_END: use
 
+// ANCHOR: game
 #[account]
 pub struct Game {
     players: [Pubkey; 2],          // (32 * 2)
@@ -10,7 +13,9 @@ pub struct Game {
     board: [[Option<Sign>; 3]; 3], // 9 * (1 + 1) = 18
     state: GameState,              // 32 + 1
 }
+// ANCHOR_END: game
 
+// ANCHOR: impl
 impl Game {
     pub const MAXIMUM_SIZE: usize = (32 * 2) + 1 + (9 * (1 + 1)) + (32 + 1);
 
@@ -110,7 +115,9 @@ impl Game {
         self.state = GameState::Tie;
     }
 }
+// ANCHOR_END: impl
 
+// ANCHOR: gamestate
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Eq)]
 pub enum GameState {
     Active,
@@ -125,9 +132,12 @@ pub enum Sign {
     X,
     O,
 }
+// ANCHOR_END: gamestate
 
+// ANCHOR: tile
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct Tile {
     row: u8,
     column: u8,
 }
+// ANCHOR_END: tile

--- a/programs/tic-tac-toe/tests/tic-tac-toe.ts
+++ b/programs/tic-tac-toe/tests/tic-tac-toe.ts
@@ -1,17 +1,28 @@
-import * as anchor from '@project-serum/anchor';
-import { AnchorError, Program } from '@project-serum/anchor';
-import { TicTacToe } from '../target/types/tic_tac_toe';
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-import { expect } from 'chai';
+import * as anchor from "@project-serum/anchor";
+import { AnchorError, Program } from "@project-serum/anchor";
+import { TicTacToe } from "../target/types/tic_tac_toe";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+// ANCHOR: chai-import
+import { expect } from "chai";
+// ANCHOR_END: chai-import
 chai.use(chaiAsPromised);
 
-async function play(program: Program<TicTacToe>, game, player, tile, expectedTurn, expectedGameState, expectedBoard) {
+// ANCHOR: play-func
+async function play(
+  program: Program<TicTacToe>,
+  game,
+  player,
+  tile,
+  expectedTurn,
+  expectedGameState,
+  expectedBoard
+) {
   await program.methods
     .play(tile)
     .accounts({
       player: player.publicKey,
-      game
+      game,
     })
     .signers(player instanceof (anchor.Wallet as any) ? [] : [player])
     .rpc();
@@ -19,19 +30,19 @@ async function play(program: Program<TicTacToe>, game, player, tile, expectedTur
   const gameState = await program.account.game.fetch(game);
   expect(gameState.turn).to.equal(expectedTurn);
   expect(gameState.state).to.eql(expectedGameState);
-  expect(gameState.board)
-    .to
-    .eql(expectedBoard);
+  expect(gameState.board).to.eql(expectedBoard);
 }
+// ANCHOR_END: play-func
 
-describe('tic-tac-toe', () => {
+describe("tic-tac-toe", () => {
   // Configure the client to use the local cluster.
   anchor.setProvider(anchor.AnchorProvider.env());
 
   const program = anchor.workspace.TicTacToe as Program<TicTacToe>;
   const programProvider = program.provider as anchor.AnchorProvider;
 
-  it('setup game!', async() => {
+  // ANCHOR: setup-game
+  it("setup game!", async () => {
     const gameKeypair = anchor.web3.Keypair.generate();
     const playerOne = programProvider.wallet;
     const playerTwo = anchor.web3.Keypair.generate();
@@ -46,16 +57,20 @@ describe('tic-tac-toe', () => {
 
     let gameState = await program.account.game.fetch(gameKeypair.publicKey);
     expect(gameState.turn).to.equal(1);
-    expect(gameState.players)
-      .to
-      .eql([playerOne.publicKey, playerTwo.publicKey]);
+    expect(gameState.players).to.eql([
+      playerOne.publicKey,
+      playerTwo.publicKey,
+    ]);
     expect(gameState.state).to.eql({ active: {} });
-    expect(gameState.board)
-      .to
-      .eql([[null,null,null],[null,null,null],[null,null,null]]);
+    expect(gameState.board).to.eql([
+      [null, null, null],
+      [null, null, null],
+      [null, null, null],
+    ]);
   });
+  // ANCHOR_END: setup-game
 
-  it('player one wins!', async () => {
+  it("player one wins!", async () => {
     const gameKeypair = anchor.web3.Keypair.generate();
     const playerOne = programProvider.wallet;
     const playerTwo = anchor.web3.Keypair.generate();
@@ -70,29 +85,32 @@ describe('tic-tac-toe', () => {
 
     let gameState = await program.account.game.fetch(gameKeypair.publicKey);
     expect(gameState.turn).to.equal(1);
-    expect(gameState.players)
-      .to
-      .eql([playerOne.publicKey, playerTwo.publicKey]);
+    expect(gameState.players).to.eql([
+      playerOne.publicKey,
+      playerTwo.publicKey,
+    ]);
     expect(gameState.state).to.eql({ active: {} });
-    expect(gameState.board)
-      .to
-      .eql([[null,null,null],[null,null,null],[null,null,null]]);
+    expect(gameState.board).to.eql([
+      [null, null, null],
+      [null, null, null],
+      [null, null, null],
+    ]);
 
     await play(
       program,
       gameKeypair.publicKey,
       playerOne,
-      {row: 0, column: 0},
+      { row: 0, column: 0 },
       2,
-      { active: {}, },
+      { active: {} },
       [
-        [{x:{}},null,null],
-        [null,null,null],
-        [null,null,null]
+        [{ x: {} }, null, null],
+        [null, null, null],
+        [null, null, null],
       ]
     );
 
-
+    // ANCHOR: not-player-turn-error
     try {
       await play(
         program,
@@ -101,13 +119,13 @@ describe('tic-tac-toe', () => {
         // change sth about the tx because
         // duplicate tx that come in too fast
         // after each other may get dropped
-        {row: 1, column: 0},
+        { row: 1, column: 0 },
         2,
-        { active: {}, },
+        { active: {} },
         [
-          [{x:{}},null,null],
-          [null,null,null],
-          [null,null,null]
+          [{ x: {} }, null, null],
+          [null, null, null],
+          [null, null, null],
         ]
       );
       chai.assert(false, "should've failed but didn't ");
@@ -117,20 +135,24 @@ describe('tic-tac-toe', () => {
       expect(err.error.errorCode.code).to.equal("NotPlayersTurn");
       expect(err.error.errorCode.number).to.equal(6003);
       expect(err.program.equals(program.programId)).is.true;
-      expect(err.error.comparedValues).to.deep.equal([playerTwo.publicKey, playerOne.publicKey]);
+      expect(err.error.comparedValues).to.deep.equal([
+        playerTwo.publicKey,
+        playerOne.publicKey,
+      ]);
     }
+    // ANCHOR_END: not-player-turn-error
 
     await play(
       program,
       gameKeypair.publicKey,
       playerTwo,
-      {row: 1, column: 0},
+      { row: 1, column: 0 },
       3,
-      { active: {}, },
+      { active: {} },
       [
-        [{x:{}},null,null],
-        [{o:{}},null,null],
-        [null,null,null]
+        [{ x: {} }, null, null],
+        [{ o: {} }, null, null],
+        [null, null, null],
       ]
     );
 
@@ -138,28 +160,29 @@ describe('tic-tac-toe', () => {
       program,
       gameKeypair.publicKey,
       playerOne,
-      {row: 0, column: 1},
+      { row: 0, column: 1 },
       4,
-      { active: {}, },
+      { active: {} },
       [
-        [{x:{}},{x: {}},null],
-        [{o:{}},null,null],
-        [null,null,null]
+        [{ x: {} }, { x: {} }, null],
+        [{ o: {} }, null, null],
+        [null, null, null],
       ]
     );
 
+    // ANCHOR: out-of-bound-error
     try {
       await play(
         program,
         gameKeypair.publicKey,
         playerTwo,
-        {row: 5, column: 1}, // out of bounds row
+        { row: 5, column: 1 }, // out of bounds row
         4,
-        { active: {}, },
+        { active: {} },
         [
-          [{x:{}},{x: {}},null],
-          [{o:{}},null,null],
-          [null,null,null]
+          [{ x: {} }, { x: {} }, null],
+          [{ o: {} }, null, null],
+          [null, null, null],
         ]
       );
       chai.assert(false, "should've failed but didn't ");
@@ -169,18 +192,19 @@ describe('tic-tac-toe', () => {
       expect(err.error.errorCode.number).to.equal(6000);
       expect(err.error.errorCode.code).to.equal("TileOutOfBounds");
     }
+    // ANCHOR_END: out-of-bound-error
 
     await play(
       program,
       gameKeypair.publicKey,
       playerTwo,
-      {row: 1, column: 1},
+      { row: 1, column: 1 },
       5,
-      { active: {}, },
+      { active: {} },
       [
-        [{x:{}},{x: {}},null],
-        [{o:{}},{o:{}},null],
-        [null,null,null]
+        [{ x: {} }, { x: {} }, null],
+        [{ o: {} }, { o: {} }, null],
+        [null, null, null],
       ]
     );
 
@@ -189,13 +213,13 @@ describe('tic-tac-toe', () => {
         program,
         gameKeypair.publicKey,
         playerOne,
-        {row: 0, column: 0},
+        { row: 0, column: 0 },
         5,
-        { active: {}, },
+        { active: {} },
         [
-          [{x:{}},{x: {}},null],
-          [{o:{}},{o:{}},null],
-          [null,null,null]
+          [{ x: {} }, { x: {} }, null],
+          [{ o: {} }, { o: {} }, null],
+          [null, null, null],
         ]
       );
       chai.assert(false, "should've failed but didn't ");
@@ -209,13 +233,13 @@ describe('tic-tac-toe', () => {
       program,
       gameKeypair.publicKey,
       playerOne,
-      {row: 0, column: 2},
+      { row: 0, column: 2 },
       5,
-      { won: { winner: playerOne.publicKey }, },
+      { won: { winner: playerOne.publicKey } },
       [
-        [{x:{}},{x: {}},{x: {}}],
-        [{o:{}},{o:{}},null],
-        [null,null,null]
+        [{ x: {} }, { x: {} }, { x: {} }],
+        [{ o: {} }, { o: {} }, null],
+        [null, null, null],
       ]
     );
 
@@ -224,13 +248,13 @@ describe('tic-tac-toe', () => {
         program,
         gameKeypair.publicKey,
         playerOne,
-        {row: 0, column: 2},
+        { row: 0, column: 2 },
         5,
-        { won: { winner: playerOne.publicKey }, },
+        { won: { winner: playerOne.publicKey } },
         [
-          [{x:{}},{x: {}},{x: {}}],
-          [{o:{}},{o:{}},null],
-          [null,null,null]
+          [{ x: {} }, { x: {} }, { x: {} }],
+          [{ o: {} }, { o: {} }, null],
+          [null, null, null],
         ]
       );
       chai.assert(false, "should've failed but didn't ");
@@ -239,9 +263,9 @@ describe('tic-tac-toe', () => {
       const err: AnchorError = _err;
       expect(err.error.errorCode.number).to.equal(6002);
     }
-  })
+  });
 
-  it('tie', async () => {
+  it("tie", async () => {
     const gameKeypair = anchor.web3.Keypair.generate();
     const playerOne = programProvider.wallet;
     const playerTwo = anchor.web3.Keypair.generate();
@@ -256,25 +280,28 @@ describe('tic-tac-toe', () => {
 
     let gameState = await program.account.game.fetch(gameKeypair.publicKey);
     expect(gameState.turn).to.equal(1);
-    expect(gameState.players)
-      .to
-      .eql([playerOne.publicKey, playerTwo.publicKey]);
+    expect(gameState.players).to.eql([
+      playerOne.publicKey,
+      playerTwo.publicKey,
+    ]);
     expect(gameState.state).to.eql({ active: {} });
-    expect(gameState.board)
-      .to
-      .eql([[null,null,null],[null,null,null],[null,null,null]]);
+    expect(gameState.board).to.eql([
+      [null, null, null],
+      [null, null, null],
+      [null, null, null],
+    ]);
 
     await play(
       program,
       gameKeypair.publicKey,
       playerOne,
-      {row: 0, column: 0},
+      { row: 0, column: 0 },
       2,
-      { active: {}, },
+      { active: {} },
       [
-        [{x:{}},null,null],
-        [null,null,null],
-        [null,null,null]
+        [{ x: {} }, null, null],
+        [null, null, null],
+        [null, null, null],
       ]
     );
 
@@ -282,13 +309,13 @@ describe('tic-tac-toe', () => {
       program,
       gameKeypair.publicKey,
       playerTwo,
-      {row: 1, column: 1},
+      { row: 1, column: 1 },
       3,
-      { active: {}, },
+      { active: {} },
       [
-        [{x:{}},null,null],
-        [null,{o:{}},null],
-        [null,null,null]
+        [{ x: {} }, null, null],
+        [null, { o: {} }, null],
+        [null, null, null],
       ]
     );
 
@@ -296,13 +323,13 @@ describe('tic-tac-toe', () => {
       program,
       gameKeypair.publicKey,
       playerOne,
-      {row: 2, column: 0},
+      { row: 2, column: 0 },
       4,
-      { active: {}, },
+      { active: {} },
       [
-        [{x:{}},null,null],
-        [null,{o:{}},null],
-        [{x:{}},null,null]
+        [{ x: {} }, null, null],
+        [null, { o: {} }, null],
+        [{ x: {} }, null, null],
       ]
     );
 
@@ -310,13 +337,13 @@ describe('tic-tac-toe', () => {
       program,
       gameKeypair.publicKey,
       playerTwo,
-      {row: 1, column: 0},
+      { row: 1, column: 0 },
       5,
-      { active: {}, },
+      { active: {} },
       [
-        [{x:{}},null,null],
-        [{o:{}},{o:{}},null],
-        [{x:{}},null,null]
+        [{ x: {} }, null, null],
+        [{ o: {} }, { o: {} }, null],
+        [{ x: {} }, null, null],
       ]
     );
 
@@ -324,13 +351,13 @@ describe('tic-tac-toe', () => {
       program,
       gameKeypair.publicKey,
       playerOne,
-      {row: 1, column: 2},
+      { row: 1, column: 2 },
       6,
-      { active: {}, },
+      { active: {} },
       [
-        [{x:{}},null,null],
-        [{o:{}},{o:{}},{x:{}}],
-        [{x:{}},null,null]
+        [{ x: {} }, null, null],
+        [{ o: {} }, { o: {} }, { x: {} }],
+        [{ x: {} }, null, null],
       ]
     );
 
@@ -338,13 +365,13 @@ describe('tic-tac-toe', () => {
       program,
       gameKeypair.publicKey,
       playerTwo,
-      {row: 0, column: 1},
+      { row: 0, column: 1 },
       7,
-      { active: {}, },
+      { active: {} },
       [
-        [{x:{}},{o:{}},null],
-        [{o:{}},{o:{}},{x:{}}],
-        [{x:{}},null,null]
+        [{ x: {} }, { o: {} }, null],
+        [{ o: {} }, { o: {} }, { x: {} }],
+        [{ x: {} }, null, null],
       ]
     );
 
@@ -352,13 +379,13 @@ describe('tic-tac-toe', () => {
       program,
       gameKeypair.publicKey,
       playerOne,
-      {row: 2, column: 1},
+      { row: 2, column: 1 },
       8,
-      { active: {}, },
+      { active: {} },
       [
-        [{x:{}},{o:{}},null],
-        [{o:{}},{o:{}},{x:{}}],
-        [{x:{}},{x:{}},null]
+        [{ x: {} }, { o: {} }, null],
+        [{ o: {} }, { o: {} }, { x: {} }],
+        [{ x: {} }, { x: {} }, null],
       ]
     );
 
@@ -366,29 +393,28 @@ describe('tic-tac-toe', () => {
       program,
       gameKeypair.publicKey,
       playerTwo,
-      {row: 2, column: 2},
+      { row: 2, column: 2 },
       9,
-      { active: {}, },
+      { active: {} },
       [
-        [{x:{}},{o:{}},null],
-        [{o:{}},{o:{}},{x:{}}],
-        [{x:{}},{x:{}},{o:{}}]
+        [{ x: {} }, { o: {} }, null],
+        [{ o: {} }, { o: {} }, { x: {} }],
+        [{ x: {} }, { x: {} }, { o: {} }],
       ]
     );
-
 
     await play(
       program,
       gameKeypair.publicKey,
       playerOne,
-      {row: 0, column: 2},
+      { row: 0, column: 2 },
       9,
-      { tie: {}, },
+      { tie: {} },
       [
-        [{x:{}},{o:{}},{x:{}}],
-        [{o:{}},{o:{}},{x:{}}],
-        [{x:{}},{x:{}},{o:{}}]
+        [{ x: {} }, { o: {} }, { x: {} }],
+        [{ o: {} }, { o: {} }, { x: {} }],
+        [{ x: {} }, { x: {} }, { o: {} }],
       ]
     );
-  })
+  });
 });


### PR DESCRIPTION
Switch to using code anchors (pun!) for code snippets from the tic-tac-toe program. This way the code in the book remains in sync without having to keep duplicating code into the book.

There were 2-3 snippets, I did not convert since they showed gradual changes before getting to the final version.

It all looks good in my local mdbook but please have a look.

_PS. I may have run Prettier over the ts test file. Forgive me!_