### PR TITLE
Fix broken link to the typedoc site

### DIFF
--- a/src/introduction/anchor_documentation.md
+++ b/src/introduction/anchor_documentation.md
@@ -1,6 +1,7 @@
 # Anchor Documentation
+
 Anchor's official documentation is split up into multiple parts, namely the guide, which is what you are reading right now and the references.
 
-There are three references. One for the [core library](https://docs.rs/anchor-lang/latest/anchor_lang/) and one for each official client library ([typescript](https://project-serum.github.io/anchor/ts/index.html) and [rust](https://docs.rs/anchor-client/latest/anchor_client/)). These references are close to the code and detailed. If you know what you are looking for and want to understand how it works more deeply, you'll find explanations there. 
+There are three references. One for the [core library](https://docs.rs/anchor-lang/latest/anchor_lang/) and one for each official client library ([typescript](https://coral-xyz.github.io/anchor/ts/index.html) and [rust](https://docs.rs/anchor-client/latest/anchor_client/)). These references are close to the code and detailed. If you know what you are looking for and want to understand how it works more deeply, you'll find explanations there.
 
 However, if you're new to anchor, you need to know what anchor has to offer before you can even try to understand it more deeply. That's what this guide is for. Its purpose is to introduce you to anchor, to help you become familiar with it. It teaches you what features are available in Anchor so you can explore them yourself in detail using the references.


### PR DESCRIPTION
### Problem

Typedoc link points to an outdated GitHub pages link as shown in https://github.com/coral-xyz/anchor-book/issues/99:

https://github.com/coral-xyz/anchor-book/blob/15edcaeba87fb7d49cfee9256369cb3c5558785c/src/introduction/anchor_documentation.md#L4

### Summary of changes

Change to use the new URL: https://coral-xyz.github.io/anchor/ts/index.html

Fixes #99