### PR TITLE
Add toolchain section in `Anchor.toml`

### DIFF
--- a/programs/tic-tac-toe/Anchor.toml
+++ b/programs/tic-tac-toe/Anchor.toml
@@ -1,3 +1,7 @@
+[toolchain]
+anchor_version = "0.29.0"
+solana_version = "1.16.20"
+
 [programs.localnet]
 tic_tac_toe = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 

--- a/programs/tic-tac-toe/Anchor.toml
+++ b/programs/tic-tac-toe/Anchor.toml
@@ -1,6 +1,6 @@
 [toolchain]
 anchor_version = "0.29.0"
-solana_version = "1.16.20"
+solana_version = "1.17.0"
 
 [programs.localnet]
 tic_tac_toe = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"


### PR DESCRIPTION
### Problem

Running the example program(s) in the book require specific Anchor and Solana CLI versions.

### Summary of changes

Specify `[toolchain]` section in `Anchor.toml` to make the examples work even if the current active CLI versions are different.