### PR TITLE
fix pda error

### DIFF
--- a/src/anchor_in_depth/PDAs.md
+++ b/src/anchor_in_depth/PDAs.md
@@ -271,7 +271,8 @@ mod puppet_master {
         puppet::cpi::set_data(
             ctx.accounts.set_data_ctx().with_signer(&[&[bump][..]]),
             data,
-        )
+        )?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
fix this error
```rust
mismatched types
expected enum `std::result::Result<(), _>`
   found enum `std::result::Result<Return<u64>, _>`rustc[Click for full compiler diagnostic](rust-analyzer-diagnostics-view:/diagnostic%20message%20[0]?0#file:///Users/levi/code/web3/solana/puppet/programs/puppet-master/src/lib.rs)
lib.rs(12, 76): expected `std::result::Result<(), anchor_lang::error::Error>` because of return type
```