### PR TITLE
Fix broken TS reference links

### DIFF
--- a/src/anchor_in_depth/errors.md
+++ b/src/anchor_in_depth/errors.md
@@ -2,18 +2,18 @@
 
 > [`AnchorError` Rust Reference](https://docs.rs/anchor-lang/latest/anchor_lang/error/struct.AnchorError.html)
 
-> [`AnchorError` Typescript Reference](https://project-serum.github.io/anchor/ts/classes/AnchorError.html)
+> [`AnchorError` Typescript Reference](https://coral-xyz.github.io/anchor/ts/classes/AnchorError.html)
 
 There are two types of errors in anchor programs. AnchorErrors and non-anchor errors.
 AnchorErrors can be divided into Anchor Internal Errors that the framework returns from inside its own code or
-custom errors which the user (you!) can return. 
+custom errors which the user (you!) can return.
 
 - AnchorErrors
   - Anchor Internal Errors
   - Custom Errors
 - Non-anchor errors.
 
-[AnchorErrors](https://docs.rs/anchor-lang/latest/anchor_lang/error/struct.AnchorError.html) provide a range of information like the error name and number or the location in the code where the error was thrown, or the account that violated a constraint (e.g. a `mut` constraint). Once thrown inside the program, [you can access the error information](https://project-serum.github.io/anchor/ts/classes/AnchorError.html) in the anchor clients like the typescript client. The typescript client also enriches the error with additional information about which program the error was thrown in and the CPI calls (which are explained [here](./CPIs.md) in the book) that led to the program from which the error was thrown from. [The milestone chapter](./milestone_project_tic-tac-toe.md) explores how all of this works together in practice. For now, let's look at how different errors can be returned from inside a program.
+[AnchorErrors](https://docs.rs/anchor-lang/latest/anchor_lang/error/struct.AnchorError.html) provide a range of information like the error name and number or the location in the code where the error was thrown, or the account that violated a constraint (e.g. a `mut` constraint). Once thrown inside the program, [you can access the error information](https://coral-xyz.github.io/anchor/ts/classes/AnchorError.html) in the anchor clients like the typescript client. The typescript client also enriches the error with additional information about which program the error was thrown in and the CPI calls (which are explained [here](./CPIs.md) in the book) that led to the program from which the error was thrown from. [The milestone chapter](./milestone_project_tic-tac-toe.md) explores how all of this works together in practice. For now, let's look at how different errors can be returned from inside a program.
 
 ## Anchor Internal Errors
 
@@ -23,7 +23,7 @@ Anchor has many different internal error codes. These are not meant to be used b
 
 ## Custom Errors
 
-You can add errors that are unique to your program by using the `error_code` attribute. 
+You can add errors that are unique to your program by using the `error_code` attribute.
 
 Simply add it to an enum with a name of your choice. You can then use the variants of the enum as errors in your program. Additionally, you can add a message attribute to the individual variants. Clients will then display this error message if the error occurs. Custom Error code numbers start at the [custom error offset](https://docs.rs/anchor-lang/latest/anchor_lang/error/constant.ERROR_CODE_OFFSET.html).
 
@@ -35,7 +35,7 @@ mod hello_anchor {
     use super::*;
     pub fn set_data(ctx: Context<SetData>, data: MyAccount) -> Result<()> {
         if data.data >= 100 {
-            return err!(MyError::DataTooLarge);    
+            return err!(MyError::DataTooLarge);
         }
         ctx.accounts.my_account.set_inner(data);
         Ok(())
@@ -53,12 +53,13 @@ pub enum MyError {
 ### require!
 
 You can use the [`require`](https://docs.rs/anchor-lang/latest/anchor_lang/macro.require.html) macro to simplify writing errors. The code above can be simplified to this (Note that the `>=` flips to `<`):
+
 ```rust,ignore
 #[program]
 mod hello_anchor {
     use super::*;
     pub fn set_data(ctx: Context<SetData>, data: MyAccount) -> Result<()> {
-        require!(data.data < 100, MyError::DataTooLarge); 
+        require!(data.data < 100, MyError::DataTooLarge);
         ctx.accounts.my_account.set_inner(data);
         Ok(())
     }


### PR DESCRIPTION
### Problem

Some of the TypeScript reference links don't work anymore.

### Summary of changes

- Fix broken TS reference links
- Format code