### PR TITLE
Fix account check

### DIFF
--- a/src/prerequisites/intro_to_solana.md
+++ b/src/prerequisites/intro_to_solana.md
@@ -187,7 +187,7 @@ The fix is simple:
 let HARDCODED_COUNTER_COUNTER_ADDRESS = SOME_ADDRESS;
 
 fn increment(accounts) {
-    if accounts.counter.key == HARDCODED_COUNTER_COUNTER_ADDRESS {
+    if accounts.counter.key != HARDCODED_COUNTER_COUNTER_ADDRESS {
         error("Wrong account type");
     }
     let counter = deserialize(accounts.counter);


### PR DESCRIPTION
Problem: Probably the book meant to forbid accounts other than the hardcoded address, but it's actually doing the opposite: allowing any address other than the hardcoded one.

Solution: Change `==` to `!=`.